### PR TITLE
Fix footer link to repository

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -10,7 +10,7 @@
     >
     and
     <a
-      href="https://github.com/apvarun/showcase-hugo-theme"
+      href="https://github.com/apvarun/showfolio-hugo-theme"
       target="_blank"
       rel="noopener noreferrer"
       class="underline hover:text-blue-800 dark:hover:text-blue-300"


### PR DESCRIPTION
Hi! The `Hugo` hyperlink in the footer currently points to a different repository. Submitting this minor fix. :)